### PR TITLE
add tests to check if each backend can support store/lookup of keys e…

### DIFF
--- a/test/backend/key_value_test.rb
+++ b/test/backend/key_value_test.rb
@@ -40,4 +40,10 @@ class I18nBackendKeyValueTest < I18n::TestCase
       I18n.t("foo", :raise => true)
     end
   end
+
+  test "key value store: can store and retrieve a translation which key ends with the escope separator character" do
+    setup_backend!
+    store_translations :'en', :"yyy." => "yyy value"
+    assert_equal("yyy value", I18n.t("yyy."))
+  end
 end if I18n::TestCase.key_value?

--- a/test/backend/memoize_test.rb
+++ b/test/backend/memoize_test.rb
@@ -44,4 +44,10 @@ class I18nBackendMemoizeTest < I18nBackendSimpleTest
     assert I18n.available_locales.include?(:copa)
     assert_equal 1, I18n.backend.spy_calls
   end
+
+  test "memoize: can store and retrieve a translation which key ends with the escope separator character" do
+    store_translations :'en', :"yyy." => "yyy value"
+    assert_equal("yyy value", I18n.t("yyy."))
+  end
+
 end

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -70,6 +70,11 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal Hash[:'en', {:foo => {:bar => 'bar', :baz => 'baz'}}], translations
   end
 
+  test "simple store and lookup: can store and retrieve a translation which key ends with the escope separator character" do
+    store_translations :'en', :"yyy." => "yyy value"
+    assert_equal("yyy value", I18n.t("yyy."))
+  end
+
   # reloading translations
 
   test "simple reload_translations: unloads translations" do


### PR DESCRIPTION
…nding in the separator character (. by default).
