### PR TITLE
Simplify options hash cacke key generation.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,3 +23,6 @@ DEPENDENCIES
   mocha
   rake
   test_declarative
+
+BUNDLED WITH
+   1.12.5

--- a/lib/i18n/backend/cache.rb
+++ b/lib/i18n/backend/cache.rb
@@ -84,13 +84,9 @@ module I18n
 
         def cache_key(locale, key, options)
           # This assumes that only simple, native Ruby values are passed to I18n.translate.
-          "i18n/#{I18n.cache_namespace}/#{locale}/#{key.hash}/#{USE_INSPECT_HASH ? options.inspect.hash : options.hash}"
+          "i18n/#{I18n.cache_namespace}/#{locale}/#{key.hash}/#{options.to_s.hash}"
         end
 
-      private
-        # In Ruby < 1.9 the following is true: { :foo => 1, :bar => 2 }.hash == { :foo => 2, :bar => 1 }.hash
-        # Therefore we must use the hash of the inspect string instead to avoid cache key colisions.
-        USE_INSPECT_HASH = RUBY_VERSION <= "1.9"
     end
   end
 end

--- a/test/backend/cache_test.rb
+++ b/test/backend/cache_test.rb
@@ -59,9 +59,8 @@ class I18nBackendCacheTest < I18n::TestCase
   end
 
   test "adds locale and hash of key and hash of options" do
-    options = { :bar=>1 }
-    options_hash = I18n::Backend::Cache::USE_INSPECT_HASH ? options.inspect.hash : options.hash
-    assert_equal "i18n//en/#{:foo.hash}/#{options_hash}", I18n.backend.send(:cache_key, :en, :foo, options)
+    options = { :bar => 1 }
+    assert_equal "i18n//en/#{:foo.hash}/#{options.to_s.hash}", I18n.backend.send(:cache_key, :en, :foo, options)
   end
 
   test "keys should not be equal" do


### PR DESCRIPTION
 This should also make it work on [rubinius](https://github.com/rubinius/rubinius) 

Where this returns true:

```
{ :foo => 1, :bar => 2 }.hash == { :foo => 2, :bar => 1 }.hash
```
